### PR TITLE
switch to debian jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ but modified to suit some of our existing conventions and needs.
 
 ## ccnmtl/django.base
 
-General, all-purpose django base image. Based on Ubuntu 14.04. Both
+General, all-purpose django base image. Based on Debian Jessie. Both
 the `django.build` and any run containers use it as a base.
 
 ## ccnmtl/django.build

--- a/django.base
+++ b/django.base
@@ -1,19 +1,18 @@
-FROM ubuntu:trusty
-RUN apt-get update
-RUN apt-get install -qyy \
+FROM debian:jessie
+RUN apt-get update && apt-get install -qyy \
 		-o APT::Install-Recommends=false -o APT::Install-Suggests=false \
-		binutils \
+		libjpeg-dev \
 		nodejs \
 		npm \
-		openssl \
-    postgresql-client \
-    python-beautifulsoup \
-    python-imaging \
-    python-ldap \
+		postgresql-client \
+		python-imaging \
+		python-pip \
 		python-setuptools \
-		python-virtualenv \
-    python-tk 
+		openssl \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 ENV PYTHONUNBUFFERED 1
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node
+RUN pip install virtualenv
 RUN virtualenv /ve
 RUN /ve/bin/pip install -U pip

--- a/django.build
+++ b/django.build
@@ -1,6 +1,7 @@
 FROM ccnmtl/django.base
 
-RUN apt-get install -qy \
+RUN apt-get update && apt-get install -qy \
+		binutils \
 		build-essential \
 		gcc \
 		libffi-dev \
@@ -9,9 +10,6 @@ RUN apt-get install -qy \
 		libexif12 \
 		libfontconfig1-dev \
 		libfreetype6-dev \
-		libjpeg-dev \
-		liblcms1 \
-		liblcms1-dev \
 		libldap2-dev \
 		libpq-dev  \
 		libsasl2-dev \
@@ -19,8 +17,13 @@ RUN apt-get install -qy \
 		libxft-dev \
 		libxml2-dev \
 		libxslt1-dev \
-    python-all-dev \
-		python-dev
+		python-all-dev \
+		python-dev \
+		python-beautifulsoup \
+		python-ldap \
+		python-tk \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 
 RUN /ve/bin/pip install wheel
 


### PR DESCRIPTION
plus some other tweaks to make the base image and deployed images
smaller. Eg, capsim's image size is reduced by about 100MB.
