### PR TITLE
add hugo docker base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 build:
 	docker build -t ccnmtl/django.base -f django.base .
 	docker build -t ccnmtl/django.build -f django.build .
+	docker build -t ccnmtl/hugo.base -f hugo.base .
 
 push:
 	docker push ccnmtl/django.base
 	docker push ccnmtl/django.build
+	docker push ccnmtl/hugo.base

--- a/hugo.base
+++ b/hugo.base
@@ -1,0 +1,10 @@
+FROM debian:jessie
+RUN apt-get update \
+ && apt-get install nodejs npm -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+ADD https://github.com/spf13/hugo/releases/download/v0.18.1/hugo_0.18.1-64bit.deb /tmp/hugo.deb
+RUN dpkg -i /tmp/hugo.deb
+RUN mkdir /app/
+EXPOSE 1313


### PR DESCRIPTION
simple docker image with hugo 0.18 and nodejs/npm stuff
installed.

Yeah, part of the point of hugo is that it's easy to install anywhere, but as more of our stuff relies on JS with jshint, eslint, webpack, etc. hugo alone isn't enough for a full dev environment. This provides a base that we can use for docker-compose setups on hugo sites to simplify development a bit.